### PR TITLE
Fix enhance integration test: wrong param name and import

### DIFF
--- a/tests/integration/test_enhance_integration.py
+++ b/tests/integration/test_enhance_integration.py
@@ -5,7 +5,7 @@ Requires: ROEX_API_KEY environment variable and test audio files
 
 import pytest
 from roex_python.client import RoExClient
-from roex_python.models import MixEnhanceRequest, MusicalStyle
+from roex_python.models import MixEnhanceRequest, EnhanceMusicalStyle
 from roex_python.utils import upload_file
 
 
@@ -29,7 +29,7 @@ class TestEnhanceIntegration:
         # Create enhancement request
         enhance_request = MixEnhanceRequest(
             audio_file_location=track_url,
-            musical_style=MusicalStyle.POP,
+            musical_style=EnhanceMusicalStyle.POP,
             is_master=False,
             fix_clipping_issues=True,
             fix_loudness_issues=True,
@@ -46,7 +46,7 @@ class TestEnhanceIntegration:
         # Retrieve enhanced track (with polling)
         enhanced = client.enhance.retrieve_enhanced_track(
             task.mixrevive_task_id,
-            max_attempts=50,
+            timeout=500,
             poll_interval=10
         )
         assert enhanced is not None


### PR DESCRIPTION
## Summary
- Fix `retrieve_enhanced_track` call in integration test: `max_attempts` -> `timeout` to match the current method signature
- Fix import: `MusicalStyle` -> `EnhanceMusicalStyle` (correct enum for the enhance endpoint)

## Test plan
- [x] 143 unit tests passing
- [ ] Run enhance integration test manually to verify (`@pytest.mark.skip` by default)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to a skipped integration test and only adjust argument names/imports to match current client APIs.
> 
> **Overview**
> Fixes the enhance integration test to match current SDK interfaces by switching the style enum from `MusicalStyle` to `EnhanceMusicalStyle` and updating the polling call to use `timeout` instead of the old `max_attempts` parameter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b2fb9d4bb00b018924bcdb0bd6b9d88577e8b7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->